### PR TITLE
Fix TLEN calculation and REF field in sam file

### DIFF
--- a/include/aligner/aligner_ksw2.hpp
+++ b/include/aligner/aligner_ksw2.hpp
@@ -1753,14 +1753,16 @@ public:
           if (sam_m2.pos > sam_m1.pos)
           {
             tlen = (sam_m2.pos + mate2->seq.l) - sam_m1.pos;
+            sam_m1.tlen = tlen;
+            sam_m2.tlen = -tlen;
           }
           else
           {
             tlen = (sam_m1.pos + mate1->seq.l) - sam_m2.pos;
+            sam_m1.tlen = -tlen;
+            sam_m2.tlen = tlen;
           }
            
-          sam_m1.tlen = tlen;
-          sam_m2.tlen = -tlen;
 
           //sam_m1.rname = idx[sam_m1.pos - 1]; // Check if necessary [This is causing the discrepency between OA Ref and Ref. Anyways REF already calculated by fill_chain function]
           //sam_m2.rname = idx[sam_m2.pos - 1];
@@ -2014,14 +2016,16 @@ orphan_paired_score_t paired_chain_orphan_score(
         if (sam_m2.pos > sam_m1.pos)
         {
           tlen = (sam_m2.pos + mate2->seq.l) - sam_m1.pos;
+          sam_m1.tlen = tlen;
+          sam_m2.tlen = -tlen;
         }
         else
         {
           tlen = (sam_m1.pos + mate1->seq.l) - sam_m2.pos;
+          sam_m1.tlen = -tlen;
+          sam_m2.tlen = tlen;
         }
 
-        sam_m1.tlen = tlen;
-        sam_m2.tlen = -tlen;
 
         // sam_m1.rname = idx[sam_m1.pos - 1];
         // sam_m2.rname = idx[sam_m2.pos - 1];


### PR DESCRIPTION
Two changes were made:

1. TLEN calculation: Added check to see which mate has the rightmost assigned position. You add the length of the read to the position of the rightmost read and then subtract the position of the leftmost read.

2. In the fill_chain function, the sam->rname seems to match sam->lift_rname which is correct behavior. However, the sam->rname is getting recalculated in paired_chain_score function (I don't know why) and this is where the rname field is being set incorrectly. I commented out those lines in this function and it seemed to work properly afterwards.

EDIT:

How TLEN is originally calculated in the file is based on the assumption that mate2 is always the rightmost read of the template which is not true. For example, we would not calculate TLEN correctly in the first (if read1 = mate2 & read2 = mate 1) and second (if read1 = mate1 & read2 = mate2) scenarios shown at the bottom of section 1.5 of the sam specification. This is the why checking the order of the mates in the template is necessary. I updated the file to make sure the leftmost mate will get assigned the positive TLEN value and the rightmost mate will get assigned the negative TLEN value. 