### PR TITLE
Use last 2021 klib commit to avoid error with memchr

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -336,9 +336,11 @@ if(NOT malloc_count_POPULATED)
 endif()
 
   ## Add klib
+set(KLIB_COMMIT "9a063b33efd841fcc42d4b9f68cb78bb528bf75b")
 FetchContent_Declare(
   klib
   GIT_REPOSITORY https://github.com/attractivechaos/klib
+  GIT_TAG ${KLIB_COMMIT}
 )
 
 FetchContent_GetProperties(klib)


### PR DESCRIPTION
The title.