### PR TITLE
Modify paired-end dispatcher logic

### DIFF
--- a/include/aligner/align_reads_dispatcher.hpp
+++ b/include/aligner/align_reads_dispatcher.hpp
@@ -154,8 +154,6 @@ void *mt_align_worker(void *param)
     kpbseq_t *learn_b = kpbseq_init();
 
     bool learning = true;
-    //std::vector<std::vector<typename aligner_t::paired_alignment_t>> alignments;
-    //std::vector<kpbseq_t *> memo;
     kpbseq_t *memo;
 
     while ((l = mt_kpbseq_read(b, mate1, mate2, b_size)) > 0)
@@ -163,45 +161,15 @@ void *mt_align_worker(void *param)
       if (learning)
       {
         kpbseq_append(learn_b, b);
-        //memo.push_back(kpbseq_init());
         memo = kpbseq_init();
-        //copy_kpbseq_t(memo.back(), b);
         copy_kpbseq_t(memo, b);
-        //alignments.push_back(std::vector<typename aligner_t::paired_alignment_t>(l));
-        //if (p->aligner->learn_fragment_model(memo.back(), alignments.back()))
         if (p->aligner->learn_fragment_model(memo))
         {
-          // for (size_t i = 0; i < alignments.size(); ++i)
-          // {
-          //   stats += p->aligner->finalize_learning(alignments[i], sam_fd);
-          //   kpbseq_destroy(memo[i]);
-          //   alignments[i].clear();alignments[i].shrink_to_fit();
-          // }
-          // memo.clear(); memo.shrink_to_fit();
-          // alignments.clear(); alignments.shrink_to_fit();
           learning = false;
           break;
         }
       }
-      // else
-      // {
-      //   stats += p->aligner->align(b, sam_fd);
-      //   if(stats.processed_reads % 10000 == 0) std::cout << ".";
-      // }
     }
-
-    // // Finalize the learned reads if there are no reads left.
-    // for (size_t i = 0; i < alignments.size(); ++i)
-    // {
-    //   stats += p->aligner->finalize_learning(alignments[i], sam_fd);
-    //   kpbseq_destroy(memo[i]);
-    //   alignments[i].clear();alignments[i].shrink_to_fit();
-    // }
-    // memo.clear(); memo.shrink_to_fit();
-    // alignments.clear(); alignments.shrink_to_fit();
-
-    // kpbseq_destroy(b);
-
 
     // Do the full alignment on the learning reads
     stats += p->aligner->align(learn_b, sam_fd);
@@ -359,8 +327,6 @@ statistics_t st_align(aligner_t *aligner, std::string pattern_filename, std::str
     kpbseq_t *b = kpbseq_init();
     int l = 0;
     bool learning = true;
-    // std::vector< std::vector<typename aligner_t::paired_alignment_t>> alignments;
-    // std::vector<kpbseq_t *> memo;
     kpbseq_t *memo;
 
     kpbseq_t *learn_b = kpbseq_init();
@@ -370,37 +336,16 @@ statistics_t st_align(aligner_t *aligner, std::string pattern_filename, std::str
       if(learning)
       {
         kpbseq_append(learn_b, b);
-        //memo.push_back(kpbseq_init());
         memo = kpbseq_init();
-        //copy_kpbseq_t(memo.back(), b);
         copy_kpbseq_t(memo, b);
-        //alignments.push_back(std::vector<typename aligner_t::paired_alignment_t>(l));
-        // if (aligner->learn_fragment_model(memo.back(), alignments.back()))
         if (aligner->learn_fragment_model(memo))
         {
-          // for( size_t i = 0; i < alignments.size(); ++i ){
-          //   stats += aligner->finalize_learning(alignments[i], sam_fd);
-          //   kpbseq_destroy(memo[i]);
-          //   alignments[i].clear(); alignments[i].shrink_to_fit();
-          // } 
-          // memo.clear(); memo.shrink_to_fit();
-          // alignments.clear(); alignments.shrink_to_fit();
           learning = false;
           break;
         }
       }
-      // else
-      // {
-      //   stats += aligner->align(b,sam_fd);
-      //   if(stats.processed_reads % 10000 == 0) std::cout << ".";
-      // }
     }
-    // if ((stats.processed_reads - pn_reads) > 1000000) {
-    //   verbose("Number of processed reads: ", stats.processed_reads);
-    //   pn_reads = stats.processed_reads;
-    // }
-    // kpbseq_destroy(b);
-
+    
     // Do the full alignment on the learning reads
     stats += aligner->align(learn_b, sam_fd);
     kpbseq_destroy(learn_b);

--- a/include/aligner/aligner_ksw2.hpp
+++ b/include/aligner/aligner_ksw2.hpp
@@ -635,80 +635,6 @@ public:
 
   } paired_alignment_t;
 
-  // // Aligning pair-ended batched sequences
-  // // Return true if the fragment model has been learned.
-  // // Assumes alignment to be allocated with the exact number of elements
-  // bool learn_fragment_model(kpbseq_t *batch, std::vector<paired_alignment_t>& alignments)
-  // {
-  //   size_t n_aligned = 0;
-
-  //   // Computing Mean and Variance using Welford's algorithm
-  //   size_t count = 0;   // Number of samples
-  //   double mean = 0.0;  // Accumulates the mean
-  //   double m2 = 0.0;    // Accumulates the squared distance from the mean
-
-  //   int l = batch->mate1->l;
-  //   for (size_t i = 0; i < l; ++i)
-  //   {
-  //     // paired_alignment_t alignment(&batch->mate1->buf[i], &batch->mate2->buf[i]);
-  //     paired_alignment_t& alignment = alignments[i];
-  //     alignment.init(&batch->mate1->buf[i], &batch->mate2->buf[i]);
-  //     if(align(alignment, false) and ((not alignment.second_best_score) or ((alignment.best_scores[0].tot - alignment.best_scores[1].tot) > ins_learning_score_gap_threshold)))
-  //     {
-  //       // Get stats
-  //       // mate_abs_distance.push_back((double)(alignment.sam_m1.tlen >= 0?alignment.sam_m1.tlen :-alignment.sam_m1.tlen));
-  //       // double value = (double)(alignment.sam_m1.tlen >= 0?alignment.sam_m1.tlen :-alignment.sam_m1.tlen);
-  //       double value = (double)(alignment.best_scores[0].dist);
-  //       double delta = value - mean;
-  //       mean += delta / (++count);
-  //       m2 += delta * (value - mean);
-  //     }
-  //   }
-
-  //   // Computes stats
-  //   double variance = m2/count;
-  //   double sampleVariance = m2/(count-1);
-  //   double std_dev = sqrt(variance);
-
-  //   __ins_mtx.lock();
-  //   if (not ins_learning_complete)
-  //   {
-  //     if (ins_count > 0)
-  //     {
-  //       size_t t_count = ins_count + count;
-  //       double delta = ins_mean - mean;
-  //       ins_m2 += m2 + (delta * delta * ins_count * count) / t_count;
-  //       ins_mean = (ins_count * ins_mean + count * mean)/ t_count;
-  //       ins_count = t_count;
-  //     }
-  //     else
-  //     {
-  //       ins_mean = mean;
-  //       ins_std_dev = std_dev;
-  //       ins_m2 = m2;
-  //       ins_count = count;
-  //     }
-  //     verbose("Number of high quality samples processed so far: ", ins_count);
-  //     ins_learning_complete = ins_learning_complete or (ins_count >= ins_learning_n);
-  //     if (ins_learning_complete)
-  //     {
-  //       ins_variance = ins_m2 / ins_count;
-  //       ins_sample_variance = ins_m2 / (ins_count - 1);
-  //       ins_std_dev = sqrt(ins_variance);
-
-  //       verbose("Insertion size estimation complete!");
-  //       verbose("Number of high quality samples: ", ins_count);
-  //       verbose("                          Mean: ", ins_mean);
-  //       verbose("                      Variance: ", ins_variance);
-  //       verbose("               Sample Variance: ", ins_sample_variance);
-  //       verbose("            Standard Deviation: ", ins_std_dev);
-  //     }
-  //   }
-  //   __ins_mtx.unlock();
-
-  //   return ins_learning_complete;
-  // }
-
   // Aligning pair-ended batched sequences
   // Return true if the fragment model has been learned.
   // Assumes alignment to be allocated with the exact number of elements
@@ -782,46 +708,6 @@ public:
 
     return ins_learning_complete;
   }
-
-  // statistics_t finalize_learning(std::vector<paired_alignment_t> &alignments, FILE *out)
-  // {
-  //   statistics_t stats;
-
-  //   for (size_t i = 0; i < alignments.size(); ++i)
-  //   {
-  //     ++stats.processed_reads;
-  //     // paired_alignment_t alignment(&batch->mate1->buf[i], &batch->mate2->buf[i]);
-  //     paired_alignment_t &alignment = alignments[i];
-  //     alignment.mean = ins_mean;
-  //     alignment.std_dev = ins_std_dev;
-
-  //     if (alignment.best_scores.size() == 0)
-  //     {
-  //       alignment.write(out);
-  //       continue;
-  //     }
-
-  //     update_best_scores(alignment);
-
-  //     if (alignment.best_scores[0].tot >= alignment.min_score)
-  //     {
-  //       size_t j = alignment.best_scores[0].chain_i;
-  //       alignment.score = paired_chain_score(alignment, j, false);
-  //       alignment.aligned = (alignment.score.tot >= alignment.min_score);
-  //     }
-  //     else if (alignment.chained)
-  //     {
-  //       ++ stats.orphan_reads;
-  //       orphan_recovery(alignment, ins_mean, ins_std_dev);
-  //       if (alignment.aligned) ++stats.orphan_recovered_reads;
-  //     }
-      
-  //     alignment.write(out);
-
-  //     if (alignment.aligned) ++stats.aligned_reads;
-  //   }
-  //   return stats;
-  // }
 
   // Aligning pair-ended batched sequences
   statistics_t align(kpbseq_t *batch, FILE *out)

--- a/include/aligner/aligner_ksw2.hpp
+++ b/include/aligner/aligner_ksw2.hpp
@@ -635,10 +635,84 @@ public:
 
   } paired_alignment_t;
 
+  // // Aligning pair-ended batched sequences
+  // // Return true if the fragment model has been learned.
+  // // Assumes alignment to be allocated with the exact number of elements
+  // bool learn_fragment_model(kpbseq_t *batch, std::vector<paired_alignment_t>& alignments)
+  // {
+  //   size_t n_aligned = 0;
+
+  //   // Computing Mean and Variance using Welford's algorithm
+  //   size_t count = 0;   // Number of samples
+  //   double mean = 0.0;  // Accumulates the mean
+  //   double m2 = 0.0;    // Accumulates the squared distance from the mean
+
+  //   int l = batch->mate1->l;
+  //   for (size_t i = 0; i < l; ++i)
+  //   {
+  //     // paired_alignment_t alignment(&batch->mate1->buf[i], &batch->mate2->buf[i]);
+  //     paired_alignment_t& alignment = alignments[i];
+  //     alignment.init(&batch->mate1->buf[i], &batch->mate2->buf[i]);
+  //     if(align(alignment, false) and ((not alignment.second_best_score) or ((alignment.best_scores[0].tot - alignment.best_scores[1].tot) > ins_learning_score_gap_threshold)))
+  //     {
+  //       // Get stats
+  //       // mate_abs_distance.push_back((double)(alignment.sam_m1.tlen >= 0?alignment.sam_m1.tlen :-alignment.sam_m1.tlen));
+  //       // double value = (double)(alignment.sam_m1.tlen >= 0?alignment.sam_m1.tlen :-alignment.sam_m1.tlen);
+  //       double value = (double)(alignment.best_scores[0].dist);
+  //       double delta = value - mean;
+  //       mean += delta / (++count);
+  //       m2 += delta * (value - mean);
+  //     }
+  //   }
+
+  //   // Computes stats
+  //   double variance = m2/count;
+  //   double sampleVariance = m2/(count-1);
+  //   double std_dev = sqrt(variance);
+
+  //   __ins_mtx.lock();
+  //   if (not ins_learning_complete)
+  //   {
+  //     if (ins_count > 0)
+  //     {
+  //       size_t t_count = ins_count + count;
+  //       double delta = ins_mean - mean;
+  //       ins_m2 += m2 + (delta * delta * ins_count * count) / t_count;
+  //       ins_mean = (ins_count * ins_mean + count * mean)/ t_count;
+  //       ins_count = t_count;
+  //     }
+  //     else
+  //     {
+  //       ins_mean = mean;
+  //       ins_std_dev = std_dev;
+  //       ins_m2 = m2;
+  //       ins_count = count;
+  //     }
+  //     verbose("Number of high quality samples processed so far: ", ins_count);
+  //     ins_learning_complete = ins_learning_complete or (ins_count >= ins_learning_n);
+  //     if (ins_learning_complete)
+  //     {
+  //       ins_variance = ins_m2 / ins_count;
+  //       ins_sample_variance = ins_m2 / (ins_count - 1);
+  //       ins_std_dev = sqrt(ins_variance);
+
+  //       verbose("Insertion size estimation complete!");
+  //       verbose("Number of high quality samples: ", ins_count);
+  //       verbose("                          Mean: ", ins_mean);
+  //       verbose("                      Variance: ", ins_variance);
+  //       verbose("               Sample Variance: ", ins_sample_variance);
+  //       verbose("            Standard Deviation: ", ins_std_dev);
+  //     }
+  //   }
+  //   __ins_mtx.unlock();
+
+  //   return ins_learning_complete;
+  // }
+
   // Aligning pair-ended batched sequences
   // Return true if the fragment model has been learned.
   // Assumes alignment to be allocated with the exact number of elements
-  bool learn_fragment_model(kpbseq_t *batch, std::vector<paired_alignment_t>& alignments)
+  bool learn_fragment_model(kpbseq_t *batch)
   {
     size_t n_aligned = 0;
 
@@ -651,7 +725,7 @@ public:
     for (size_t i = 0; i < l; ++i)
     {
       // paired_alignment_t alignment(&batch->mate1->buf[i], &batch->mate2->buf[i]);
-      paired_alignment_t& alignment = alignments[i];
+      paired_alignment_t alignment;
       alignment.init(&batch->mate1->buf[i], &batch->mate2->buf[i]);
       if(align(alignment, false) and ((not alignment.second_best_score) or ((alignment.best_scores[0].tot - alignment.best_scores[1].tot) > ins_learning_score_gap_threshold)))
       {
@@ -709,45 +783,45 @@ public:
     return ins_learning_complete;
   }
 
-  statistics_t finalize_learning(std::vector<paired_alignment_t> &alignments, FILE *out)
-  {
-    statistics_t stats;
+  // statistics_t finalize_learning(std::vector<paired_alignment_t> &alignments, FILE *out)
+  // {
+  //   statistics_t stats;
 
-    for (size_t i = 0; i < alignments.size(); ++i)
-    {
-      ++stats.processed_reads;
-      // paired_alignment_t alignment(&batch->mate1->buf[i], &batch->mate2->buf[i]);
-      paired_alignment_t &alignment = alignments[i];
-      alignment.mean = ins_mean;
-      alignment.std_dev = ins_std_dev;
+  //   for (size_t i = 0; i < alignments.size(); ++i)
+  //   {
+  //     ++stats.processed_reads;
+  //     // paired_alignment_t alignment(&batch->mate1->buf[i], &batch->mate2->buf[i]);
+  //     paired_alignment_t &alignment = alignments[i];
+  //     alignment.mean = ins_mean;
+  //     alignment.std_dev = ins_std_dev;
 
-      if (alignment.best_scores.size() == 0)
-      {
-        alignment.write(out);
-        continue;
-      }
+  //     if (alignment.best_scores.size() == 0)
+  //     {
+  //       alignment.write(out);
+  //       continue;
+  //     }
 
-      update_best_scores(alignment);
+  //     update_best_scores(alignment);
 
-      if (alignment.best_scores[0].tot >= alignment.min_score)
-      {
-        size_t j = alignment.best_scores[0].chain_i;
-        alignment.score = paired_chain_score(alignment, j, false);
-        alignment.aligned = (alignment.score.tot >= alignment.min_score);
-      }
-      else if (alignment.chained)
-      {
-        ++ stats.orphan_reads;
-        orphan_recovery(alignment, ins_mean, ins_std_dev);
-        if (alignment.aligned) ++stats.orphan_recovered_reads;
-      }
+  //     if (alignment.best_scores[0].tot >= alignment.min_score)
+  //     {
+  //       size_t j = alignment.best_scores[0].chain_i;
+  //       alignment.score = paired_chain_score(alignment, j, false);
+  //       alignment.aligned = (alignment.score.tot >= alignment.min_score);
+  //     }
+  //     else if (alignment.chained)
+  //     {
+  //       ++ stats.orphan_reads;
+  //       orphan_recovery(alignment, ins_mean, ins_std_dev);
+  //       if (alignment.aligned) ++stats.orphan_recovered_reads;
+  //     }
       
-      alignment.write(out);
+  //     alignment.write(out);
 
-      if (alignment.aligned) ++stats.aligned_reads;
-    }
-    return stats;
-  }
+  //     if (alignment.aligned) ++stats.aligned_reads;
+  //   }
+  //   return stats;
+  // }
 
   // Aligning pair-ended batched sequences
   statistics_t align(kpbseq_t *batch, FILE *out)

--- a/include/common/kpbseq.h
+++ b/include/common/kpbseq.h
@@ -203,6 +203,19 @@ inline static void kbseq_realloc(kbseq_t *b)
 }
 
 /**
+ * \brief resize a to size a + b
+ *
+ * \param a the variable to resize to a + b
+ * \param b the variable to account for 
+ */
+inline static void kbseq_resize(kbseq_t *a, kbseq_t *b)
+{
+    a->m = a->l + b->l + 1;
+    kroundup32(a->m);
+    a->buf = (kseq_t *)realloc(a->buf, a->m * sizeof(kseq_t));
+}
+
+/**
  * \brief append seq to b.
  * 
  * \param b the batch o sequences
@@ -246,6 +259,19 @@ inline static void copy_kbseq_t(kbseq_t *a, kbseq_t *b)
     for (size_t i = 0; i < b->l; ++i)
         kbseq_push_back(a, &b->buf[i]);
 }
+
+/**
+ * \brief append b to a
+ *
+ * \param a the destination variable
+ * \param b the source variable
+ */
+ inline static void append_kbseq_t(kbseq_t *a, kbseq_t *b)
+ {
+    kbseq_resize(a,b);
+    for (size_t i = 0; i < b->l; ++i)
+        kbseq_push_back(a, &b->buf[i]); 
+ }
 
 /**
  * \brief Read n sequences from seq and append them to b.
@@ -328,6 +354,19 @@ inline static size_t kpbseq_read(kpbseq_t *p, kseq_t *mate1_s, kseq_t *mate2_s, 
     return l1;
 }
 
+/**
+ * \brief Append all mate sequences from b to a
+ *
+ * \param a the batch where the sequences will be appended to
+ * \param b the batch that contains the sequences to append to a
+ */
+
+ inline static void kpbseq_append(kpbseq_t *a, kpbseq_t *b)
+ {
+    append_kbseq_t(a->mate1, b->mate1);
+    append_kbseq_t(a->mate2, b->mate2);
+ }
+ 
 inline static void kpbseq_destroy(kpbseq_t *p)
 {
     kbseq_destroy(p->mate1);


### PR DESCRIPTION
This modifies the paired-end dispatcher logic. Instead of storing the partial alignments of the learning reads until learning is complete, we instead should not store them and redo the full alignment for these reads after learning is complete. Of course,  we have to do some redundant alignment work as a result, but since it is only for a small amount of reads (~1000) it is worth it for the memory savings. This reduces the peak memory significantly from my testings (90+% when redoing the chr21 experiments). 