### PR TITLE
Decide based on left MEM of chain whether to do full alignment of chain

### DIFF
--- a/include/aligner/chain.hpp
+++ b/include/aligner/chain.hpp
@@ -39,6 +39,16 @@ typedef struct{
             reversed = true;
         }
     }
+
+    void reset()
+    {
+        if (reversed)
+        {
+            std::reverse(anchors.begin(), anchors.end());
+            reversed = false;
+        }
+    }
+
 } chain_t;
 
 // typedef struct{


### PR DESCRIPTION
Adds a check to see whether the left MEM position of the current chain lifts over to the left MEM position of a previous chain. Additionally, checks if both chains had the same chain score value. If both conditions are true, then the current chain is skipped.