### PR TITLE
Change seed occ filter behavior

### DIFF
--- a/include/aligner/seed_finder.hpp
+++ b/include/aligner/seed_finder.hpp
@@ -156,8 +156,8 @@ public:
             occs.push_back(prev);
             std::tie(prev,lcp) = get_prev_occ_with_lcp(prev, len);
 
-            if (filter_seeds and (occs.size() > n_seeds_thr) )
-                return false;
+            // if (filter_seeds and (occs.size() > n_seeds_thr) )
+            //     return false;
         }
 
         return true;
@@ -175,8 +175,8 @@ public:
             occs.push_back(next);
             std::tie(next,lcp) = get_next_occ_with_lcp(next, len);
 
-            if (filter_seeds and (occs.size() > n_seeds_thr) )
-                return false;
+            // if (filter_seeds and (occs.size() > n_seeds_thr) )
+            //     return false;
         }
 
         return true;


### PR DESCRIPTION
Modifies the seed occurrence filter. Now seed occurrences are tracked per ref genome in the pangenome and the occurrences greater than the threshold value are removed from the respective genome. For example, if a MEM had an occurrence distribution like this ref1: 100  ref2: 150 ref3: 205 and the threshold was 200, 5 MEMs would only be removed from ref3.