### PR TITLE
Fix the direction filter and track MEM occurances better in seed finder

### DIFF
--- a/include/aligner/seed_finder.hpp
+++ b/include/aligner/seed_finder.hpp
@@ -260,6 +260,7 @@ public:
     bool find_MEM_occs(mem_t &mem)
     {
         mem.occs.push_back(mem.pos);
+        mem.total_occ++;
 
         if (!find_MEM_above(mem.pos, mem.len, mem.occs, mem.count_dict, mem.total_occ, mem.num_filtered)) return false;
         if (!find_MEM_below(mem.pos, mem.len, mem.occs, mem.count_dict, mem.total_occ, mem.num_filtered)) return false;
@@ -296,6 +297,8 @@ public:
             mems.push_back(mem_t(upper_suffix, ll, i, mate, rl));
 
             mem_t &mem = mems.back();
+            mem.occs.push_back(upper_suffix);
+            mem.total_occ++;
             if ((not find_MEM_above(upper_suffix, mem.len, mem.occs, mem.count_dict, mem.total_occ, mem.num_filtered)) or
                 (not find_MEM_below(lower_suffix, mem.len, mem.occs, mem.count_dict, mem.total_occ, mem.num_filtered)))
             {


### PR DESCRIPTION
- Fixed the direction filter which did not work as intended after the switch from find_seeds to find_mems + populate_seeds
- Track MEM occurance better