### PR TITLE
Fix issue in fill_orphan where position references linear reference instead of pangenome

### DIFF
--- a/include/aligner/aligner_ksw2.hpp
+++ b/include/aligner/aligner_ksw2.hpp
@@ -1268,6 +1268,13 @@ public:
 
     if (best_scores[0].tot < al.min_score)
     {
+      // If read will be orphaned then clear the AA tag info
+      al.sam_m1.alt_haplotypes.clear();
+      al.sam_m1.alt_pos.clear();
+      al.sam_m1.alt_scores.clear();
+      al.sam_m2.alt_haplotypes.clear();
+      al.sam_m2.alt_pos.clear();
+      al.sam_m2.alt_scores.clear();
       MTIME_END(2); //Timing helper
       MTIME_TSAFE_MERGE;
       return false;
@@ -2682,7 +2689,7 @@ orphan_paired_score_t paired_chain_orphan_score(
           sam->rlen = ref_len;
 
           score.score = ez.score;
-          score.pos = ref_occ;
+          score.pos = start;
           // score.pos = start;
           free(l_ref);
         }  else { // Read is unmapped because it align on an insertion of length > readlength


### PR DESCRIPTION
This causes issues in paired_chain_orphan_score when it calculates the distance between mate 1 and mate 2 on line 2455 in aligner_ksw2.hpp. The position returned from the chain_score function call was referencing the pangenome location whereas the fill_orphan was referencing the linear reference location. This caused the distance calculated to be very large causing  int overflow for the score.tot variable resulting in negative value that gets set to 0. This seemingly caused the orphan reads to have alignment score of 0 erroneously. 

Also now clear the AA fields for orphan paired-end reads.