### PR TITLE
Update the PFP submodule commit 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ message(STATUS "Install lib directory: ${CMAKE_INSTALL_LIBDIR}")
 # About this project
 # ------------------------------------------------------------------------------
 project(moni-align)
-set(VERSION_MAJOR "0")
-set(VERSION_MINOR "1")
+set(VERSION_MAJOR "1")
+set(VERSION_MINOR "0")
 set(VERSION_PATCH "0")
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ___  ___            _         ___  _ _
 \_|  |_/\___/|_| |_|_|      \_| |_/_|_|\__, |_| |_|
                                         __/ |      
                                        |___/       
-                                            ver 0.1.0
+                                            ver 1.0.0
 ```
 A Read Aligner with Multi-Genome References.
 


### PR DESCRIPTION
Updates the PFP submodule commit. Commit removes malloc_count from pfp since it seemingly is causing the munmap_chunk(): invalid pointer error when built with gcc >9. Not 100% sure this is what is actually causing the error, but there is no malloc calls in the main pfp project  and removing malloc count gets rid of the error with the test and Chr21 data sets.

Also updates the version number of Moni-align to be v1.0.0